### PR TITLE
Feature: Permanize UUID

### DIFF
--- a/src/routes/info.js
+++ b/src/routes/info.js
@@ -40,12 +40,17 @@ const Info = () => {
   };
 
   const handleSave = async () => {
-    setLocked(true);
     const updatedData = { ...data, status, comment };
-    const hash = await digestMessage(`${data.name?.last}${data.name?.first}${data.dob?.date}`);
-    const key = hash.substring(0,20);
+    let key = id;
+    if (!key) {
+      const hash = await digestMessage(`${data.name?.last}${data.name?.first}${data.dob?.date}`);
+      key = hash.substring(0,20);
+    }
+
     localStorage.setItem(key, JSON.stringify(updatedData));
     setData(updatedData);
+    setLocked(true);
+
     navigate(`/info/${key}`, { replace: true });
   };
 


### PR DESCRIPTION
Ensure that an existing UUID is not overwritten if candidate's data is modified or the hash algorithm changes in the future.

Checks if the id value is present in the URL. If so, use that. If not, this is a new record.

Warning: There is an edge-case where a new random user may collide with an existing recording. Not solving for this because a real DB wouldn't have this problem.